### PR TITLE
Handle more fedora-messaging exceptions when publishing messages

### DIFF
--- a/resultsdb/messaging.py
+++ b/resultsdb/messaging.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 try:
     from fedora_messaging.api import Message, publish
-    from fedora_messaging.exceptions import PublishReturned, ConnectionException
+    from fedora_messaging.exceptions import PublishReturned, PublishTimeout, PublishForbidden, ConnectionException
 except ImportError:
     if app.config.get('MESSAGE_BUS_PUBLISH_TASKOTRON') or app.config.get('MESSAGE_BUS_PLUGIN') == 'fedmsg':
         log.error('fedora-messaging must be installed if "MESSAGE_BUS_PUBLISH_TASKOTRON" is '
@@ -113,6 +113,10 @@ def publish_taskotron_message(result, include_job_url=False):
         log.debug("Message published")
     except PublishReturned as e:
         log.error('Fedora Messaging broker rejected message {}: {}'.format(msg.id, e))
+    except PublishTimeout:
+        log.error('Timeout publishing message {}'.format(msg.id))
+    except PublishForbidden as e:
+        log.error('Permission error publishing message {}: {}'.format(msg.id, e))
     except ConnectionException as e:
         log.error('Error sending message {}: {}'.format(msg.id, e.reason))
 
@@ -165,6 +169,10 @@ class FedmsgPlugin(MessagingPlugin):
             log.debug("Message published")
         except PublishReturned as e:
             log.error('Fedora Messaging broker rejected message {}: {}'.format(msg.id, e))
+        except PublishTimeout:
+            log.error('Timeout publishing message {}'.format(msg.id))
+        except PublishForbidden as e:
+            log.error('Permission error publishing message {}: {}'.format(msg.id, e))
         except ConnectionException as e:
             log.error('Error sending message {}: {}'.format(msg.id, e.reason))
 


### PR DESCRIPTION
As well as PublishReturned and ConnectionException, messaging
can raise PublishTimeout (publishing timed out) or
PublishForbidden (publishing was denied for lack of permission)
when you attempt to publish a message. We should handle these
as well. At present it seems like if this happens, the exception
being unhandled ultimately causes WSGI to return a 500 or 504
error to the client that submitted the result; the client may
then try and submit the result again, leading to it being
duplicated many times. If we handle the exception instead, the
client should get a successful response and not re-submit the
result. The message not being published is still a problem, but
probably not as bad as clients constantly re-submitted results
forever.

Signed-off-by: Adam Williamson <awilliam@redhat.com>