### PR TITLE
 Avoid deploying misconfigured messaging plugin

### DIFF
--- a/resultsdb/__init__.py
+++ b/resultsdb/__init__.py
@@ -187,7 +187,7 @@ def setup_messaging(app):
     plugin_args = app.config["MESSAGE_BUS_KWARGS"]
     app.messaging_plugin = load_messaging_plugin(
         name=plugin_name,
-        kwargs=plugin_args,
+        plugin_args=plugin_args,
     )
 
 

--- a/resultsdb/controllers/common.py
+++ b/resultsdb/controllers/common.py
@@ -4,7 +4,6 @@ from flask import current_app as app
 
 from resultsdb.models import db
 from resultsdb.messaging import (
-    load_messaging_plugin,
     create_message,
     publish_taskotron_message,
 )
@@ -28,13 +27,10 @@ def commit_result(result):
         result.outcome,
     )
 
-    if app.config["MESSAGE_BUS_PUBLISH"]:
+    if app.messaging_plugin:
         app.logger.debug("Preparing to publish message for result id %d", result.id)
-        plugin = load_messaging_plugin(
-            name=app.config["MESSAGE_BUS_PLUGIN"],
-            kwargs=app.config["MESSAGE_BUS_KWARGS"],
-        )
-        plugin.publish(create_message(result))
+        message = create_message(result)
+        app.messaging_plugin.publish(message)
 
     if app.config["MESSAGE_BUS_PUBLISH_TASKOTRON"]:
         app.logger.debug("Preparing to publish Taskotron message for result id %d", result.id)

--- a/resultsdb/messaging.py
+++ b/resultsdb/messaging.py
@@ -205,7 +205,7 @@ class StompPlugin(MessagingPlugin):
         required = ["connection", "destination"]
         for attr in required:
             if getattr(self, attr, None) is None:
-                raise ValueError("%r required for %r." % (attr, self))
+                raise ValueError(f"Missing {attr!r} option for STOMP messaging plugin")
 
     def publish(self, msg):
         msg = json.dumps(msg)

--- a/resultsdb/messaging.py
+++ b/resultsdb/messaging.py
@@ -224,7 +224,7 @@ class StompPlugin(MessagingPlugin):
             conn.disconnect()
 
 
-def load_messaging_plugin(name, kwargs):
+def load_messaging_plugin(name, plugin_args):
     """Instantiate and return the appropriate messaging plugin."""
     points = pkg_resources.iter_entry_points("resultsdb.messaging.plugins")
     classes = {"dummy": DummyPlugin}
@@ -241,4 +241,4 @@ def load_messaging_plugin(name, kwargs):
         raise TypeError("%s %r does not extend MessagingPlugin." % (name, cls))
 
     log.debug("Instantiating plugin %r named %s" % (cls, name))
-    return cls(**kwargs)
+    return cls(**plugin_args)

--- a/testing/test_app.py
+++ b/testing/test_app.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+
+from pytest import raises
+
+from resultsdb import setup_messaging
+
+
+def test_app_messaging(app):
+    assert app.messaging_plugin is not None
+    assert type(app.messaging_plugin).__name__ == "DummyPlugin"
+
+
+def test_app_messaging_none():
+    app = Mock()
+    app.config = {"MESSAGE_BUS_PUBLISH": False}
+    setup_messaging(app)
+    app.logger.info.assert_called_once_with("No messaging plugin selected")
+
+
+def test_app_messaging_stomp():
+    app = Mock()
+    app.config = {
+        "MESSAGE_BUS_PUBLISH": True,
+        "MESSAGE_BUS_PLUGIN": "stomp",
+        "MESSAGE_BUS_KWARGS": {
+            "destination": "results.new",
+            "connection": {
+                "host_and_ports": [("localhost", 1234)],
+            },
+        },
+    }
+    setup_messaging(app)
+    app.logger.info.assert_called_once_with("Using messaging plugin %s", "stomp")
+
+
+def test_app_messaging_stomp_bad():
+    app = Mock()
+    app.config = {
+        "MESSAGE_BUS_PUBLISH": True,
+        "MESSAGE_BUS_PLUGIN": "stomp",
+        "MESSAGE_BUS_KWARGS": {
+            "connection": {
+                "host_and_ports": [("localhost", 1234)],
+            },
+        },
+    }
+    expected_error = "Missing 'destination' option for STOMP messaging plugin"
+    with raises(ValueError, match=expected_error):
+        setup_messaging(app)

--- a/testing/test_general.py
+++ b/testing/test_general.py
@@ -211,9 +211,9 @@ If you ran `python setup.py develop` and are still seeing this error, then:
         with raises(stomp.exception.ConnectFailedException):
             plugin.publish({})
 
-        assert len(mock_stomp().send.mock_calls) == 0
-        assert len(mock_stomp().connect.mock_calls) == 1
-        assert len(mock_stomp().disconnect.mock_calls) == 0
+        mock_stomp().connect.assert_called_once()
+        mock_stomp().send.assert_not_called()
+        mock_stomp().disconnect.assert_not_called()
 
     def test_stomp_publish_send_failed(self, mock_stomp):
         plugin = messaging.load_messaging_plugin("stomp", MESSAGE_BUS_KWARGS)
@@ -222,9 +222,10 @@ If you ran `python setup.py develop` and are still seeing this error, then:
         with raises(stomp.exception.StompException):
             plugin.publish({})
 
-        assert len(mock_stomp().send.mock_calls) == 1
-        assert len(mock_stomp().connect.mock_calls) == 1
-        assert len(mock_stomp().disconnect.mock_calls) == 1
+        mock_stomp().connect.assert_called_once()
+        mock_stomp().send.assert_called_once()
+        mock_stomp().disconnect.assert_called_once()
+
 
 class TestGetResultsParseArgs:
     # TODO: write something!


### PR DESCRIPTION
Initializes messaging plugin at start which would effectively cancel deployment of a broken app.

Add simple tests for STOMP messaging plugin.