### PR TITLE
Fix authorization failure responses

### DIFF
--- a/resultsdb/__init__.py
+++ b/resultsdb/__init__.py
@@ -200,9 +200,29 @@ def register_handlers(app):
     def bad_request(error):
         return jsonify({"message": "Bad request"}), 400
 
+    @app.errorhandler(401)
+    def unauthorized(error):
+        app.logger.warning("Unauthorized access: %s", error)
+        return jsonify({"message": str(error)}), 401
+
+    @app.errorhandler(403)
+    def forbidden(error):
+        app.logger.warning("Permission denied: %s", error)
+        return jsonify({"message": str(error)}), 403
+
     @app.errorhandler(404)
     def not_found(error):
         return jsonify({"message": "Not found"}), 404
+
+    @app.errorhandler(500)
+    def internal_server_error(error):
+        app.logger.error("Internal error: %s", error)
+        return jsonify({"message": "Internal Server Error"}), 500
+
+    @app.errorhandler(502)
+    def bad_gateway(error):
+        app.logger.error("External error received: %s", error)
+        return jsonify({"message": "Bad Gateway"}), 502
 
 
 def init_session(app):

--- a/testing/functest_api_v20.py
+++ b/testing/functest_api_v20.py
@@ -52,7 +52,7 @@ class TestFuncApiV20(TestCase):
                 "This test requires PostgreSQL to work properly. "
                 "You can disable it by setting NO_CAN_HAS_POSTGRES "
                 "env variable to any non-empty value.\n"
-                f'Current DB URI: { app.config["SQLALCHEMY_DATABASE_URI"] }'
+                f'Current DB URI: {app.config["SQLALCHEMY_DATABASE_URI"]}'
             )
 
         assert db.engine.name == "postgresql"


### PR DESCRIPTION
Messages and logging need to be improved for the new authenticated API to troubleshoot issues.

Failure to authorize a request with the service must be logged.

If permission is denied to post a data (or access an endpoint), 403 Forbidden status code must be returned (currently it is 401).

Failure to find user in LDAP should be send back to user (with 403 response including the test case name)

In case of LDAP errors, the service should return 502 status code (not 4XX).

Return JSON formatted responses consistently.

JIRA: RHELWF-10633