### PR TITLE
Add API to create generic results

### DIFF
--- a/resultsdb/authorization.py
+++ b/resultsdb/authorization.py
@@ -39,6 +39,10 @@ def match_testcase_permissions(testcase, permissions):
 
 
 def verify_authorization(user, testcase, permissions, ldap_host, ldap_searches):
+    """
+    Raises an exception if the user is not permitted to publish a result for
+    the testcase.
+    """
     if not (ldap_host and ldap_searches):
         raise InternalServerError(
             "LDAP_HOST and LDAP_SEARCHES also need to be defined if PERMISSIONS is defined"
@@ -47,7 +51,7 @@ def verify_authorization(user, testcase, permissions, ldap_host, ldap_searches):
     allowed_groups = []
     for permission in match_testcase_permissions(testcase, permissions):
         if user in permission.get("users", []):
-            return True
+            return
         allowed_groups += permission.get("groups", [])
 
     try:
@@ -67,7 +71,7 @@ def verify_authorization(user, testcase, permissions, ldap_host, ldap_searches):
     for cur_ldap_search in ldap_searches:
         groups = get_group_membership(ldap, user, con, cur_ldap_search)
         if any(g in groups for g in allowed_groups):
-            return True
+            return
         any_groups_found = any_groups_found or len(groups) > 0
 
     raise Forbidden(

--- a/resultsdb/controllers/api_v2.py
+++ b/resultsdb/controllers/api_v2.py
@@ -479,6 +479,14 @@ def get_result(result_id):
 @api.route("/results", methods=["POST"])
 @validate()
 def create_result(body: CreateResultParams):
+    return create_result_any_data(body)
+
+
+def create_result_any_data(body: CreateResultParams):
+    """
+    Allows creating test results with data not checked by any schema (in
+    contrast to v3 API).
+    """
     if body.data:
         invalid_keys = [key for key in body.data.keys() if ":" in key]
         if invalid_keys:

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,9 @@ envlist = py3,mypy
 requires =
     poetry
     tox-docker
+    # requests-2.32.0 breaks docker
+    # https://github.com/docker/docker-py/issues/3256
+    requests<2.32.0
 
 [pytest]
 minversion=2.0


### PR DESCRIPTION
The new /api/v3/results endpoint accepts the same data as POST
/api/v2.0/results but supports OIDC authentication and permission
control.

Other users/groups won't be able to POST results to this endpoint unless
they have a permission mapping with testcase pattern matching
"ANY-DATA:<testcase_name>" (instead of just "<testcase_name>" as in the
other v3 endpoints).

JIRA: RHELWF-11168