### PR TITLE
Avoid overriding number of threads for WSGI process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ RUN /app/entrypoint.sh python -c 'import resultsdb' \
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["mod_wsgi-express", "start-server", "/usr/share/resultsdb/resultsdb.wsgi", \
     "--user", "apache", "--group", "apache", \
-    "--port", "5001", "--threads", "5", \
+    "--port", "5001", \
     "--include-file", "/etc/httpd/conf.d/resultsdb.conf", \
     "--log-level", "info", \
     "--log-to-terminal", \


### PR DESCRIPTION
It should be possible to set the number of threads in configuration.

The default number of threads is 15. See:
https://modwsgi.readthedocs.io/en/master/configuration-directives/WSGIDaemonProcess.html

JIRA: RHELWF-12572