### PR TITLE
Allow to customize mod_wsgi arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,13 +114,4 @@ RUN /app/entrypoint.sh python -c 'import resultsdb' \
     && /app/entrypoint.sh resultsdb --help
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["mod_wsgi-express", "start-server", "/usr/share/resultsdb/resultsdb.wsgi", \
-    "--user", "apache", "--group", "apache", \
-    "--port", "5001", "--threads", "5", \
-    "--include-file", "/etc/httpd/conf.d/resultsdb.conf", \
-    "--log-level", "info", \
-    "--log-to-terminal", \
-    "--access-log", \
-    "--startup-log" \
-]
 USER 1001:0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,21 @@ set -e
 
 # shellcheck disable=SC1091
 . /venv/bin/activate
-exec "$@"
+
+if [[ $# == 0 ]]; then
+    exec mod_wsgi-express \
+        start-server \
+        /usr/share/resultsdb/resultsdb.wsgi \
+        --user=apache \
+        --group=apache \
+        --processes="${MOD_WSGI_PROCESSES:-1}" \
+        --threads="${MOD_WSGI_THREADS:-5}" \
+        --port="${MOD_WSGI_PORT:-5001}" \
+        --include-file=/etc/httpd/conf.d/resultsdb.conf \
+        --log-level="${MOD_WSGI_LOG_LEVEL:-info}" \
+        --log-to-terminal \
+        --access-log \
+        --startup-log
+else
+    exec "$@"
+fi


### PR DESCRIPTION
This allows to customize arguments passed to mod_wsgi-express using environment variables when starting the container (MOD_WSGI_PROCESSES, MOD_WSGI_THREADS, MOD_WSGI_PORT, MOD_WSGI_LOG_LEVEL).

JIRA: RHELWF-12572