### PR TITLE
Make the 400 error handler better

### DIFF
--- a/resultsdb/__init__.py
+++ b/resultsdb/__init__.py
@@ -198,7 +198,8 @@ def register_handlers(app):
     # TODO: find out why error handler works for 404 but not for 400
     @app.errorhandler(400)
     def bad_request(error):
-        return jsonify({"message": "Bad request"}), 400
+        app.logger.error("Bad request: %s", error)
+        return jsonify({"message": str(error)}), 400
 
     @app.errorhandler(401)
     def unauthorized(error):


### PR DESCRIPTION
This error handler does nothing but hide the real problem. Make it more like the others.

Still, I'm not sure why any of these exist. All they really seem to do is obfuscate the real problem. OK, I guess they add app logging, but even the ones that pass through 'error' are probably hiding a lot of other useful information?