### PR TITLE
Use uv sync in Dockerfile to pin dependencies to lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,12 +56,8 @@ ARG COMMIT_TIMESTAMP
 # hadolint ignore=SC1091
 RUN set -ex \
     && export PATH=/root/.local/bin:"$PATH" \
-    && . /venv/bin/activate \
     && uv version "2.2.0.dev$COMMIT_TIMESTAMP+git.$SHORT_COMMIT" \
-    && uv build --wheel \
-    && version=$(uv version --short) \
-    && pip install --no-cache-dir dist/resultsdb-"$version"-py3*.whl \
-    && deactivate \
+    && UV_PROJECT_ENVIRONMENT=/venv uv sync --frozen --no-dev --no-editable \
     && mv /venv /mnt/rootfs \
     && mkdir -p /mnt/rootfs/app \
     && cp -v entrypoint.sh /mnt/rootfs/app


### PR DESCRIPTION
Replace "uv build --wheel && pip install" with "uv sync --frozen --no-dev --no-editable" so the container installs exact versions from uv.lock instead of resolving from PyPI at build time.

Keep "python3 -m venv --system-site-packages /venv" since resultsdb needs system packages (mod_wsgi, packaging, six) visible in the venv.